### PR TITLE
Ignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
+CMakeCache.txt
+CMakeFiles
+Makefile
+_deps/*
+bliss/
+cmake_install.cmake
+conauto/
+dejavu*
 nauty/
 saucy/
-conauto/
-bliss/


### PR DESCRIPTION
This PR just adds minimally to the `.gitignore` file to ignore the files generated by `cmake`, and `make`.